### PR TITLE
JWK Thumbprint and JWS protected header generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "JSON Web Key for JavaScript",
   "main": "src/index.js",
   "scripts": {
-    "test": "./node_modules/.bin/_mocha test -w",
+    "test": "./node_modules/.bin/nyc ./node_modules/.bin/_mocha test",
     "jsdoc": "./node_modules/.bin/jsdoc -c jsdoc.json -r",
-    "coverage": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- test"
+    "coverage": "./node_modules/.bin/nyc --reporter=lcov ./node_modules/.bin/_mocha test"
   },
   "repository": {
     "type": "git",
@@ -42,10 +42,10 @@
     "chai": "^4.1.1",
     "chai-as-promised": "^7.1.1",
     "codecov": "^2.3.0",
-    "istanbul": "^0.4.5",
     "jsdoc": "^3.5.4",
     "mocha": "^3.5.0",
     "nock": "^9.0.14",
+    "nyc": "^11.1.0",
     "sinon": "^2.1.0",
     "sinon-chai": "^2.12.0"
   },

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "dependencies": {
     "@trust/jwa": "^0.4.5",
     "@trust/webcrypto": "^0.4.0",
+    "base64url": "^2.0.0",
     "node-fetch": "^1.7.2",
     "sift": "^5.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "JSON Web Key for JavaScript",
   "main": "src/index.js",
   "scripts": {
-    "test": "./node_modules/.bin/nyc ./node_modules/.bin/_mocha test",
-    "jsdoc": "./node_modules/.bin/jsdoc -c jsdoc.json -r",
-    "coverage": "./node_modules/.bin/nyc --reporter=lcov ./node_modules/.bin/_mocha test"
+    "test": "nyc _mocha test",
+    "jsdoc": "jsdoc -c jsdoc.json -r",
+    "coverage": "nyc --reporter=lcov _mocha test"
   },
   "repository": {
     "type": "git",

--- a/src/JWK.js
+++ b/src/JWK.js
@@ -305,6 +305,7 @@ class JWK {
    *
    * @example <caption>SHA-256 Thumbprint</caption>
    * jwk.thumbprint()
+   *   .then(console.log)
    * //
    * // (line breaks for display only)
    * //

--- a/src/JWK.js
+++ b/src/JWK.js
@@ -275,6 +275,52 @@ class JWK {
     hash.update(json)
     return base64url(hash.digest())
   }
+
+  /**
+   * generateProtected
+   *
+   * @description
+   * Use key metadata to generate a JWS protected header object.
+   *
+   * @example <caption>Basic JWS Header with JWC</caption>
+   * jwk.generateProtected({ jwc: 'base64url encoded compact jwc' })
+   * // => { alg: 'RS256',
+   * //      kid: 'abcd123$',
+   * //      jwc: 'base64url encoded compact jwc' }
+   *
+   * @example <caption>Basic JWS Header with JKU</caption>
+   * jwk.generateProtected({ jku: 'https://example.com/jwks' })
+   * // => { alg: 'RS256',
+   * //      kid: 'abcd123$',
+   * //      jku: 'https://example.com/jwks' }
+   *
+   * @param  {Object} props - Additional properties to include in header.
+   * @return {Object} JWS Header
+   */
+  generateProtected (props) {
+    let { alg, kid, key_ops, use } = this
+    let header = Object.assign({}, { alg, kid }, props)
+
+    // Check key_ops or use
+    if (!(Array.isArray(key_ops) && key_ops.includes('sign')) && !(use && use === 'sig')) {
+      throw new DataError('Invalid key usage option')
+    }
+
+    // Check for mandatory properties
+    if (!header.alg) {
+      throw new DataError('\'alg\' is required')
+    }
+
+    if (!header.kid) {
+      throw new DataError('\'kid\' is required')
+    }
+
+    if (!header.jku && !header.jwc) {
+      throw new DataError('Either \'jku\' or \'jwc\' is required')
+    }
+
+    return header
+  }
 }
 
 /**

--- a/src/JWK.js
+++ b/src/JWK.js
@@ -319,29 +319,29 @@ class JWK {
   }
 
   /**
-   * generateProtected
+   * getProtectedHeader
    *
    * @description
    * Use key metadata to generate a JWS protected header object.
    *
    * @example <caption>Basic JWS Header with JWC</caption>
-   * jwk.generateProtected({ jwc: 'base64url encoded compact jwc' })
+   * jwk.getProtectedHeader({ jwc: 'base64url encoded compact jwc' })
    * // => { alg: 'RS256',
    * //      kid: 'abcd123$',
    * //      jwc: 'base64url encoded compact jwc' }
    *
    * @example <caption>Basic JWS Header with JKU</caption>
-   * jwk.generateProtected({ jku: 'https://example.com/jwks' })
+   * jwk.getProtectedHeader({ jku: 'https://example.com/jwks' })
    * // => { alg: 'RS256',
    * //      kid: 'abcd123$',
    * //      jku: 'https://example.com/jwks' }
    *
-   * @param  {Object} props - Additional properties to include in header.
+   * @param  {Object} params - Additional properties to include in header.
    * @return {Object} JWS Header
    */
-  generateProtected (props) {
+  getProtectedHeader (params) {
     let { alg, kid, key_ops, use } = this
-    let header = Object.assign({}, { alg, kid }, props)
+    let header = Object.assign({}, { alg, kid }, params)
 
     // Check key_ops or use
     if (!(Array.isArray(key_ops) && key_ops.includes('sign')) && !(use && use === 'sig')) {

--- a/src/JWKSet.js
+++ b/src/JWKSet.js
@@ -18,15 +18,6 @@ const JWK = require('./JWK')
 const { DataError, OperationError } = require('./errors')
 
 /**
- * Random KID Generator
- * @ignore
- */
-function random (byteLen) {
-  let value = crypto.getRandomValues(new Uint8Array(byteLen))
-  return Buffer.from(value).toString('hex')
-}
-
-/**
  * JWKSet
  * @ignore
  */
@@ -279,10 +270,7 @@ class JWKSet {
 
     return cryptoKeyPromise
       .then(({ privateKey, publicKey }) => [privateKey, publicKey])
-      .then(keys => {
-        let kid = random(8)
-        return Promise.all(keys.map(key => JWK.fromCryptoKey(key, { alg, kid })))
-      })
+      .then(keys => Promise.all(keys.map(key => JWK.fromCryptoKey(key, { alg }))))
       .then(keys => {
         this.keys = this.keys.concat(keys)
         return keys

--- a/test/JWKSpec.js
+++ b/test/JWKSpec.js
@@ -111,7 +111,6 @@ describe('JWK', () => {
 
     it('should assign key thumbprint as kid if not present on data or options', () => {
       let jwk = new JWK(ECPublicJWKNoKid)
-      console.log(jwk)
       jwk.kid.should.equal(ecThumbprint)
     })
 

--- a/test/JWKSpec.js
+++ b/test/JWKSpec.js
@@ -268,12 +268,14 @@ describe('JWK', () => {
   })
 
   describe('thumbprint', () => {
-    let ec, rsa, sym, kty, inv
+    let ec, ecPrv, rsa, rsaPrv, sym, kty, inv
 
     before(() => {
       return Promise.all([
         JWK.importKey(ECPublicJWK).then(key => ec = key),
+        JWK.importKey(ECPrivateJWK).then(key => ecPrv = key),
         JWK.importKey(RSAPublicJWK).then(key => rsa = key),
+        JWK.importKey(RSAPrivateJWK).then(key => rsaPrv = key),
         JWK.importKey(A256GCMJWK).then(key => sym = key),
         Promise.resolve(new JWK(ECPublicJWKNoKty)).then(key => kty = key),
         Promise.resolve(new JWK(ECPublicJWKInvalidKty)).then(key => inv = key)
@@ -281,31 +283,40 @@ describe('JWK', () => {
     })
 
     it('should return a promise', () => {
-      rsa.thumbprint().should.be.fulfilled
+      return rsa.thumbprint().should.be.fulfilled
     })
 
     it('should return a string', () => {
-      rsa.thumbprint().should.eventually.be.a('string')
+      return rsa.thumbprint().should.eventually.be.a('string')
     })
 
     it('should resolve a thumbprint for RSA keys', () => {
-      rsa.thumbprint().should.eventually.equal(rsaThumbprint)
+      return rsa.thumbprint().should.eventually.equal(rsaThumbprint)
     })
 
     it('should resolve a thumbprint for EC keys', () => {
-      ec.thumbprint().should.eventually.equal(ecThumbprint)
+      return ec.thumbprint().should.eventually.equal(ecThumbprint)
     })
 
     it('should resolve a thumbprint for symmetric keys', () => {
-      sym.thumbprint().should.eventually.equal(symThumbprint)
+      return sym.thumbprint().should.eventually.equal(symThumbprint)
+    })
+
+    it('should resolve the same thumbprint for public and private keys', () => {
+      return Promise.all([
+        ec.thumbprint().then(print => print.should.equal(ecThumbprint)),
+        ecPrv.thumbprint().then(print => print.should.equal(ecThumbprint)),
+        rsa.thumbprint().then(print => print.should.equal(rsaThumbprint)),
+        rsaPrv.thumbprint().then(print => print.should.equal(rsaThumbprint))
+      ])
     })
 
     it('should reject if the JWK does not have a kty', () => {
-      kty.thumbprint().should.be.rejectedWith('Invalid \'kty\'')
+      return kty.thumbprint().should.be.rejectedWith('Invalid \'kty\'')
     })
 
     it('should reject if the kty is not valid', () => {
-      inv.thumbprint().should.be.rejectedWith('Invalid \'kty\'')
+      return inv.thumbprint().should.be.rejectedWith('Invalid \'kty\'')
     })
   })
 

--- a/test/JWKSpec.js
+++ b/test/JWKSpec.js
@@ -109,9 +109,8 @@ describe('JWK', () => {
       jwk.kid.should.equal('2')
     })
 
-    it('should assign key thumbprint as kid if not present on data or options', () => {
-      let jwk = new JWK(ECPublicJWKNoKid)
-      jwk.kid.should.equal(ecThumbprint)
+    it('should throw if kid is not present on data or options', () => {
+      expect(() => new JWK(ECPublicJWKNoKid)).to.throw('Valid \'kid\' required for JWK')
     })
 
     it('should copy non-standard key metadata', () => {
@@ -134,6 +133,12 @@ describe('JWK', () => {
     it('should have a cryptoKey property', () => {
       return JWK.importKey(ECPrivateJWK).then(jwk => {
         jwk.should.haveOwnProperty('cryptoKey')
+      })
+    })
+
+    it('should calculate the JWK thumbprint if no `kid` is provided', () => {
+      return JWK.importKey(ECPublicJWKNoKid, {}).then(jwk => {
+        jwk.kid.should.equal(ecThumbprint)
       })
     })
   })
@@ -275,28 +280,32 @@ describe('JWK', () => {
       ])
     })
 
+    it('should return a promise', () => {
+      rsa.thumbprint().should.be.fulfilled
+    })
+
     it('should return a string', () => {
-      rsa.thumbprint().should.be.a('string')
+      rsa.thumbprint().should.eventually.be.a('string')
     })
 
-    it('should produce a thumbprint for RSA keys', () => {
-      rsa.thumbprint().should.equal(rsaThumbprint)
+    it('should resolve a thumbprint for RSA keys', () => {
+      rsa.thumbprint().should.eventually.equal(rsaThumbprint)
     })
 
-    it('should produce a thumbprint for EC keys', () => {
-      ec.thumbprint().should.equal(ecThumbprint)
+    it('should resolve a thumbprint for EC keys', () => {
+      ec.thumbprint().should.eventually.equal(ecThumbprint)
     })
 
-    it('should produce a thumbprint for symmetric keys', () => {
-      sym.thumbprint().should.equal(symThumbprint)
+    it('should resolve a thumbprint for symmetric keys', () => {
+      sym.thumbprint().should.eventually.equal(symThumbprint)
     })
 
-    it('should throw if the JWK does not have a kty', () => {
-      expect(() => kty.thumbprint()).to.throw('Invalid \'kty\'')
+    it('should reject if the JWK does not have a kty', () => {
+      kty.thumbprint().should.be.rejectedWith('Invalid \'kty\'')
     })
 
-    it('should throw if the kty is not valid', () => {
-      expect(() => inv.thumbprint()).to.throw('Invalid \'kty\'')
+    it('should reject if the kty is not valid', () => {
+      inv.thumbprint().should.be.rejectedWith('Invalid \'kty\'')
     })
   })
 

--- a/test/JWKSpec.js
+++ b/test/JWKSpec.js
@@ -320,7 +320,7 @@ describe('JWK', () => {
     })
   })
 
-  describe('generateProtected', () => {
+  describe('getProtectedHeader', () => {
     let ec, ecPub, rsa, sym, noAlg, noKid, noOps, useEc
     let jkuParams = { jku: 'https://example.com/jwks' }
     let jwcParams = { jwc: 'compact serialization jwc' }
@@ -339,52 +339,52 @@ describe('JWK', () => {
     })
 
     it('should return an object', () => {
-      let header = ec.generateProtected(jkuParams)
+      let header = ec.getProtectedHeader(jkuParams)
       header.should.be.an('object')
       expect(header).to.not.be.null
     })
 
     it('should throw if `key_ops` does not contain \'sign\' and `use` is not \'sig\'', () => {
-      expect(() => sym.generateProtected(jkuParams)).to.throw('Invalid key usage option')
-      expect(() => noOps.generateProtected(jkuParams)).to.throw('Invalid key usage option')
+      expect(() => sym.getProtectedHeader(jkuParams)).to.throw('Invalid key usage option')
+      expect(() => noOps.getProtectedHeader(jkuParams)).to.throw('Invalid key usage option')
     })
 
     it('should accept either `key_ops` or `use`', () => {
-      ec.generateProtected(jkuParams)
+      ec.getProtectedHeader(jkuParams)
       ec.key_ops.should.include('sign')
       expect(ec.use).to.be.undefined
-      useEc.generateProtected(jkuParams)
+      useEc.getProtectedHeader(jkuParams)
       useEc.use.should.equal('sig')
       expect(useEc.key_ops).to.be.undefined
     })
 
     it('should contain an \'alg\'', () => {
-      ec.generateProtected(jkuParams)
+      ec.getProtectedHeader(jkuParams)
         .alg.should.equal(ec.alg)
     })
 
     it('should throw if \'alg\' is omitted', () => {
-      expect(() => noAlg.generateProtected(jkuParams)).to.throw('\'alg\' is required')
+      expect(() => noAlg.getProtectedHeader(jkuParams)).to.throw('\'alg\' is required')
     })
 
     it('should contain a \'kid\'', () => {
-      ec.generateProtected(jkuParams)
+      ec.getProtectedHeader(jkuParams)
         .kid.should.equal(ec.kid)
     })
 
     it('should throw if \'kid\' is omitted', () => {
-      expect(() => noKid.generateProtected(jkuParams)).to.throw('\'kid\' is required')
+      expect(() => noKid.getProtectedHeader(jkuParams)).to.throw('\'kid\' is required')
     })
 
     it('should contain a \'jku\' or a \'jwc\'', () => {
-      ec.generateProtected(jkuParams)
+      ec.getProtectedHeader(jkuParams)
         .jku.should.equal(jkuParams.jku)
-      ec.generateProtected(jwcParams)
+      ec.getProtectedHeader(jwcParams)
         .jwc.should.equal(jwcParams.jwc)
     })
 
     it('should throw if \'jku\' and \'jwc\' are omitted', () => {
-      expect(() => ec.generateProtected()).to.throw('Either \'jku\' or \'jwc\' is required')
+      expect(() => ec.getProtectedHeader()).to.throw('Either \'jku\' or \'jwc\' is required')
     })
   })
 })


### PR DESCRIPTION
JWK Thumbprint as per [RFC7638](https://tools.ietf.org/html/rfc7638) (#5) and and JWS header generation and validation as per #4 (still under discussion).

Tests and documentation are done as well. This would be a minor version bump.

The only thing outstanding on this is: naming the JWS header generation method... it is currently called `generateProtected`. Suggestions?